### PR TITLE
Fix error and enhance stability by explicitly specifying keyword argu…

### DIFF
--- a/slahmr/preproc/launch_slam.py
+++ b/slahmr/preproc/launch_slam.py
@@ -201,5 +201,5 @@ if __name__ == "__main__":
         for seq in args.seqs[:1]:
             subseqs, idcs = split_sequence(args, seq)
             for idcs, (start, end) in zip(idcs, subseqs):
-                cmd = get_slam_command(args, seq, start, end)
+                cmd = get_slam_command(args, seq, start=start, end=end)
                 ex.submit(launch_job, args.gpus, cmd)


### PR DESCRIPTION
The get_slam_command function is defined with the parameters `shot_idx=None, start=0, end=-1` following the required parameters `args`, `seq`.  i.e., `get_slam_command(args, seq, shot_idx=None, start=0, end=-1):`

The original call to `get_slam_command(args, seq, start, end)` on line 204 treats `start` and `end` as the third and fourth positional arguments. However, according to the function definition, the third positional argument is expected to be `shot_idx`, not `start`.

Utilizing the original code syntax get_slam_command(args, seq, start, end) leads to errors with specific datasets, such as 3dpw. Specifically, the get_command function, located on line 158 of launch_slam.py, passes `start=-1` and `end=-1`. Consequently, on line 55 of run_slam.py, this results in a call to `return [os.path.join(img_dir, name) for name in image_list[-1:-1:stride]]`, which will cause errors for the following code.